### PR TITLE
constrain trigger of release action

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -80,7 +80,7 @@ jobs:
             const state = pulls.data[0].state;
             const mergeSHA = pulls.data[0].merge_commit_sha;
 
-            const IS_RELEASE = (state == 'closed') && (mergSHA == github.sha);
+            const IS_RELEASE = (state == 'closed') && (mergeSHA == github.sha);
 
             core.exportVariable('IS_RELEASE', `${IS_RELEASE}`);
 

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -80,11 +80,11 @@ jobs:
             const state = pulls.data[0].state;
             const mergeSHA = pulls.data[0].merge_commit_sha;
 
-            const IS_RELEASE = (state == 'closed') && (mergeSHA == github.sha);
+            const IS_RELEASE = (state == 'closed') && (mergeSHA == context.sha);
 
             console.log(`State: ${state}`);
             console.log(`mergeSHA: ${mergeSHA}`);
-            console.log(`pushSHA: ${github.sha}`);
+            console.log(`pushSHA: ${context.sha}`);
             console.log(`IS_RELEASE: ${IS_RELEASE}`);
 
             core.exportVariable('IS_RELEASE', `${IS_RELEASE}`);

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -33,10 +33,6 @@ jobs:
             echo "Pre-release flagged: $($isPreRelease)"
             echo "IS_PRE_RELEASE=$($isPreRelease)" | Out-File $env:GITHUB_ENV -Encoding utf8 -Append
 
-            $isRelease = "${{ github.base_ref }}".StartsWith("release-") -and [System.Convert]::ToBoolean("${{ github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == 'true' }}")
-            echo "Release flagged: $($isRelease)"
-            echo "IS_RELEASE=$($isRelease)" | Out-File $env:GITHUB_ENV -Encoding utf8 -Append
-
       # checks if pre-release patch version can be determined from existing release tags or if we start at 0
       - name: GitHub Script checks for existing version tags
         id: existing_version
@@ -64,6 +60,30 @@ jobs:
               core.exportVariable('MANUAL_VERSION', `${VERSION_NUMBER}.0-rc.0`);
             }
             
+      # if not a pre release, check if there is a pull request that has closed + merged with the commit SHA of this push
+      - name: GitHub Script checks for merged pull request
+        id: merged_pull_request
+        uses: actions/github-script@v4.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: github.event_name == 'push'
+        with:
+          script: |
+            // get all pull requests for this repo
+            const pulls = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed'
+            });
+
+            // get the state of the latest pull request for this repo
+            const state = pulls[0].state;
+            const mergeSHA = pulls[0].merge_commit_sha;
+
+            const IS_RELEASE = (state == 'closed') && (mergSHA == github.sha);
+
+            core.exportVariable('IS_RELEASE', `${IS_RELEASE}`);
+
       # Create a new release to auto-increment (or use manual version number)
       - name: Create new release
         id: create_release
@@ -71,7 +91,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MANUAL_VERSION: ${{ env.MANUAL_VERSION }}
-        if: env.IS_PRE_RELEASE == 'True' || env.IS_RELEASE == 'True'
+        if: env.IS_PRE_RELEASE == 'True' || env.IS_RELEASE == 'true'
         with:
           release_name: ${{ env.RELEASE_VERSION }}
           body: |

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           script: |
             // get all pull requests for this repo
-            const pulls = await github.rest.pulls.list({
+            const pulls = await github.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'closed'

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -72,9 +72,18 @@ jobs:
             // get all pull requests for this repo
             const pulls = await github.pulls.list({
               owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'closed'
+              repo: context.repo.repo
             });
+
+            console.log(pulls);
+
+            const pulls2 = await github.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'all'
+            });
+
+            console.log(pulls2);
 
             // get the state of the latest pull request for this repo
             const state = pulls[0].state;

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -84,7 +84,7 @@ jobs:
 
             console.log(`State: ${state}`);
             console.log(`mergeSHA: ${mergeSHA}`);
-            console.log(`pushSHA: ${github.SHA}`);
+            console.log(`pushSHA: ${github.sha}`);
             console.log(`IS_RELEASE: ${IS_RELEASE}`);
 
             core.exportVariable('IS_RELEASE', `${IS_RELEASE}`);

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -72,22 +72,13 @@ jobs:
             // get all pull requests for this repo
             const pulls = await github.pulls.list({
               owner: context.repo.owner,
-              repo: context.repo.repo
-            });
-
-            console.log(pulls);
-
-            const pulls2 = await github.pulls.list({
-              owner: context.repo.owner,
               repo: context.repo.repo,
-              state: 'all'
+              state: 'closed'
             });
-
-            console.log(pulls2);
 
             // get the state of the latest pull request for this repo
-            const state = pulls[0].state;
-            const mergeSHA = pulls[0].merge_commit_sha;
+            const state = pulls.data[0].state;
+            const mergeSHA = pulls.data[0].merge_commit_sha;
 
             const IS_RELEASE = (state == 'closed') && (mergSHA == github.sha);
 

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -33,7 +33,7 @@ jobs:
             echo "Pre-release flagged: $($isPreRelease)"
             echo "IS_PRE_RELEASE=$($isPreRelease)" | Out-File $env:GITHUB_ENV -Encoding utf8 -Append
 
-            $isRelease = "${{ github.ref_name }}".StartsWith("release-") -and [System.Convert]::ToBoolean("${{ github.event_name == 'push' }}")
+            $isRelease = "${{ github.base_ref }}".StartsWith("release-") -and [System.Convert]::ToBoolean("${{ github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == 'true' }}")
             echo "Release flagged: $($isRelease)"
             echo "IS_RELEASE=$($isRelease)" | Out-File $env:GITHUB_ENV -Encoding utf8 -Append
 

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -82,6 +82,11 @@ jobs:
 
             const IS_RELEASE = (state == 'closed') && (mergeSHA == github.sha);
 
+            console.log(`State: ${state}`);
+            console.log(`mergeSHA: ${mergeSHA}`);
+            console.log(`pushSHA: ${github.SHA}`);
+            console.log(`IS_RELEASE: ${IS_RELEASE}`);
+
             core.exportVariable('IS_RELEASE', `${IS_RELEASE}`);
 
       # Create a new release to auto-increment (or use manual version number)


### PR DESCRIPTION
Previously a full Release would be run when opening a branch named like 'release-**'. Now the state of the repository is properly checked for a matching Pull Request that has been merged, and which has a matching SHA to the push to a release branch.