### PR TITLE
Add platform notes

### DIFF
--- a/.github/workflows/generate-readme.yml
+++ b/.github/workflows/generate-readme.yml
@@ -12,6 +12,7 @@ jobs:
         with:
           repository: 'Keyfactor/actions'
           path: './actions/'
+          ref: 'add-platform-text'
 
       - uses: Keyfactor/jinja2-action@v1.2.0-multiple-data-files
         with:

--- a/readme-templates/readme.md.tpl
+++ b/readme-templates/readme.md.tpl
@@ -11,7 +11,7 @@
 ---
 
 {# Additional {{ integration_type }} platform template includes will go in this next section #}
-{% if integration_type == "orchestrator" %}
+{% if (integration_type == "orchestrator") and (about.orchestrator.win.supportsInventoryFoo is defined) %}
 {% include "./actions/readme-templates/readme_platform_orchestrator.tpl" ignore missing %}
 {% endif %}
 ---

--- a/readme-templates/readme.md.tpl
+++ b/readme-templates/readme.md.tpl
@@ -11,7 +11,7 @@
 ---
 
 {# Additional {{ integration_type }} platform template includes will go in this next section #}
-{% if (integration_type == "orchestrator") and (about.orchestrator.win.supportsInventoryFoo is defined) %}
+{% if (integration_type == "orchestrator") and (about.orchestrator.win.supportsInventory is defined) %}
 {% include "./actions/readme-templates/readme_platform_orchestrator.tpl" ignore missing %}
 {% endif %}
 ---

--- a/readme-templates/readme.md.tpl
+++ b/readme-templates/readme.md.tpl
@@ -9,6 +9,12 @@
 {{ shared.descriptions[integration_type] }}
 
 ---
+
+{# Additional {{ integration_type }} platform template includes will go in this next section #}
+{% if integration_type == "orchestrator" %}
+{% include "./actions/readme-templates/readme_platform_orchestrator.tpl" ignore missing %}
+{% endif %}
+---
 {# the readme_source.md file should be the general README content in markdown form #}
 {% include "readme_source.md" %}
 

--- a/readme-templates/readme_platform_orchestrator.tpl
+++ b/readme-templates/readme_platform_orchestrator.tpl
@@ -1,6 +1,7 @@
 ## Platform notes
 
-This integration performs different capabilities depending on the platform
+This plugin performs different capabilities depending on the platform
+
 On Windows: {{ about.orchestrator.win.platformSupport }} 
 
 On Linux: {{ about.orchestrator.linux.platformSupport }} 

--- a/readme-templates/readme_platform_orchestrator.tpl
+++ b/readme-templates/readme_platform_orchestrator.tpl
@@ -1,4 +1,6 @@
-The {{ name }} {{ shared.descriptions[integration_type] }} performs different capabilities depending on the platform
+## Platform notes
+
+This integration performs different capabilities depending on the platform
 On Windows: {{ about.orchestrator.win.platformSupport }} 
 
 On Linux: {{ about.orchestrator.linux.platformSupport }} 

--- a/readme-templates/readme_platform_orchestrator.tpl
+++ b/readme-templates/readme_platform_orchestrator.tpl
@@ -1,11 +1,6 @@
-## Platform notes
+## Platform Specific Notes
 
-This plugin performs different capabilities depending on the platform where Keyfactor Command is installed
-
-On Windows: {{ about.orchestrator.win.platformSupport }} 
-
-On Linux: {{ about.orchestrator.linux.platformSupport }} 
-
+The Keyfactor Universal Orchestrator may be installed on either Windows or Linux based platforms. The certificate operations supported by a capability may vary based what platform the capability is installed on. The table below indicates what capabilities are supported based on which platform the encompassing Universal Orchestrator is running.
 | Operation | Win | Linux |
 |-----|-----|------|
 |Supports Management Add|{% if about.orchestrator.win.supportsManagementAdd %}&check;{% else %} {% endif %} |{% if about.orchestrator.linux.supportsManagementAdd %}&check;{% else %} {% endif %} |

--- a/readme-templates/readme_platform_orchestrator.tpl
+++ b/readme-templates/readme_platform_orchestrator.tpl
@@ -1,0 +1,4 @@
+The {{ name }} {{ shared.descriptions[integration_type] }} performs different capabilities depending on the platform
+On Windows: {{ about.orchestrator.win.platformSupport }} 
+
+On Linux: {{ about.orchestrator.lin.platformSupport }} 

--- a/readme-templates/readme_platform_orchestrator.tpl
+++ b/readme-templates/readme_platform_orchestrator.tpl
@@ -5,3 +5,13 @@ This plugin performs different capabilities depending on the platform where Keyf
 On Windows: {{ about.orchestrator.win.platformSupport }} 
 
 On Linux: {{ about.orchestrator.linux.platformSupport }} 
+
+| Operation | Win | Linux |
+|-----|-----|------|
+|Supports Management Add|{% if about.orchestrator.win.supportsManagementAdd %}&check;{% else %} {% endif %} |{% if about.orchestrator.linux.supportsManagementAdd %}&check;{% else %} {% endif %} |
+|Supports Management Remove|{% if about.orchestrator.win.supportsManagementRemove %}&check;{% else %} {% endif %} |{% if about.orchestrator.linux.supportsManagementRemove %}&check;{% else %} {% endif %} |
+|Supports Create Store|{% if about.orchestrator.win.supportsCreateStore %}&check;{% else %} {% endif %} |{% if about.orchestrator.linux.supportsCreateStore %}&check;{% else %} {% endif %} |
+|Supports Discovery|{% if about.orchestrator.win.supportsDiscovery %}&check;{% else %} {% endif %} |{% if about.orchestrator.linux.supportsDiscovery %}&check;{% else %} {% endif %} |
+|Supports Renrollment|{% if about.orchestrator.win.supportsReenrollment %}&check;{% else %} {% endif %} |{% if about.orchestrator.linux.supportsReenrollment %}&check;{% else %} {% endif %} |
+|Supports Inventory|{% if about.orchestrator.win.supportsInventory %}&check;{% else %} {% endif %} |{% if about.orchestrator.linux.supportsInventory %}&check;{% else %} {% endif %} |
+

--- a/readme-templates/readme_platform_orchestrator.tpl
+++ b/readme-templates/readme_platform_orchestrator.tpl
@@ -1,4 +1,4 @@
 The {{ name }} {{ shared.descriptions[integration_type] }} performs different capabilities depending on the platform
 On Windows: {{ about.orchestrator.win.platformSupport }} 
 
-On Linux: {{ about.orchestrator.lin.platformSupport }} 
+On Linux: {{ about.orchestrator.linux.platformSupport }} 

--- a/readme-templates/readme_platform_orchestrator.tpl
+++ b/readme-templates/readme_platform_orchestrator.tpl
@@ -1,6 +1,6 @@
 ## Platform notes
 
-This plugin performs different capabilities depending on the platform
+This plugin performs different capabilities depending on the platform where Keyfactor Command is installed
 
 On Windows: {{ about.orchestrator.win.platformSupport }} 
 


### PR DESCRIPTION
Additional platform-specific notes have been added to orchestrator (integration_type) readme. Additional fields in manifest are required to include the new text
[Example manifest from v1.0.1 ](https://github.com/Keyfactor/integration-template/blob/orchestrator-platform-readme/integration-manifest.json)
[Epic 36586](https://devops.corp.keyfactor.com/MainCollection/SolutionEngineering/_workitems/edit/36586)