### PR TITLE
fix failed build when about properties not present

### DIFF
--- a/readme-templates/readme.md.tpl
+++ b/readme-templates/readme.md.tpl
@@ -11,7 +11,7 @@
 ---
 
 {# Additional {{ integration_type }} platform template includes will go in this next section #}
-{% if (integration_type == "orchestrator") and (about.orchestrator.win.supportsInventory is defined) %}
+{% if (integration_type == "orchestrator") and (about is defined) %}
 {% include "./actions/readme-templates/readme_platform_orchestrator.tpl" ignore missing %}
 {% endif %}
 ---


### PR DESCRIPTION
tested with missing "about" properties for older project builds