### PR TITLE
fix for PAM template not generating readme

### DIFF
--- a/readme-templates/readme_platform_orchestrator.md
+++ b/readme-templates/readme_platform_orchestrator.md
@@ -54,3 +54,5 @@ To have the __Server Password__ field resolved by the `Hashicorp-Vault` provider
 ~~~
 
 This text would be entered in as the value for the __Server Password__, instead of entering in the actual password. The Orchestrator will attempt to use the PAM Provider to retrieve the __Server Password__. If PAM should not be used, just directly enter in the value for the field.
+
+{% endif %}

--- a/readme-templates/readme_platform_orchestrator.md
+++ b/readme-templates/readme_platform_orchestrator.md
@@ -24,33 +24,33 @@ The secrets that this orchestrator extension supports for use with a PAM Provide
 
 {% include "./readme-src/readme-pam-support.md" %}
 
-It is not necessary to implement all of the secrets available to be managed by a PAM provider.  For each value that you want managed by a PAM provider, simply enter the key value inside your specific PAM provider that will hold this value into the corresponding field when setting up the certificate store, discovery job, or API call.
+It is not necessary to use a PAM Provider for all of the secrets available above. If a PAM Provider should not be used, simply enter in the actual value to be used, as normal.
 
-Setting up a PAM provider for use involves adding an additional section to the manifest.json file for this extension as well as setting up the PAM provider you will be using.  Each of these steps is specific to the PAM provider you will use and are documented in the specific GitHub repo for that provider.  For a list of Keyfactor supported PAM providers, please reference the [Keyfactor Integration Catalog](https://keyfactor.github.io/integrations-catalog/content/pam).
+If a PAM Provider will be used for one of the fields above, start by referencing the [Keyfactor Integration Catalog](https://keyfactor.github.io/integrations-catalog/content/pam). The GitHub repo for the PAM Provider to be used contains important information such as the format of the `json` needed. What follows is an example but does not reflect the `json` values for all PAM Providers as they have different "instance" and "initialization" parameter names and values.
 
+### Example PAM Provider Setup
 
-### Register the PAM Provider
+To use a PAM Provider to resolve a field, in this example the __Server Password__ will be resolved by the `Hashicorp-Vault` provider, first install the PAM Provider extension from the [Keyfactor Integration Catalog](https://keyfactor.github.io/integrations-catalog/content/pam) on the Universal Orchestrator.
 
-A PAM Provider needs to be registered on the Universal Orchestrator in the same way other extensions are. Create a folder for the specific PAM Provider to be added, and place the contents of the PAM Provider into the folder. There needs to be a manifest.json with the PAM Provider.
+Next, complete configuration of the PAM Provider on the UO by editing the `manifest.json` of the __PAM Provider__ (e.g. located at extensions/Hashicorp-Vault/manifest.json). The "initialization" parameters need to be entered here:
 
-After a manifest.json is added, the final step for configuration is setting the "provider-level" parameters for the PAM Provider. These are also known as the "initialization-level" parameters. These need to be placed in a json file that gets loaded by the Orchestrator by default. 
+~~~ json
+  "Keyfactor:PAMProviders:Hashicorp-Vault:InitializationInfo": {
+    "Host": "http://127.0.0.1:8200",
+    "Path": "v1/secret/data",
+    "Token": "xxxxxx"
+  }
+~~~
 
-example manifest.json for MY-PROVIDER-NAME
-```
-{
-    "extensions": {
-        "Keyfactor.Platform.Extensions.IPAMProvider": {
-            "PAMProviders.MY-PROVIDER-NAME.PAMProvider": {
-                "assemblyPath": "my-pam-provider.dll",
-                "TypeFullName": "Keyfactor.Extensions.Pam.MyPamProviderClass"
-            }
-        }
-    },
-    "Keyfactor:PAMProviders:MY-PROVIDER-NAME:InitializationInfo": {
-        "InitParam1": "InitValue1",
-        "InitParam2": "InitValue2"
-    }
-}
-```
+After these values are entered, the Orchestrator needs to be restarted to pick up the configuration. Now the PAM Provider can be used on other Orchestrator Extensions.
 
-{% endif %}
+### Use the PAM Provider
+With the PAM Provider configured as an extenion on the UO, a `json` object can be passed instead of an actual value to resolve the field with a PAM Provider. Consult the [Keyfactor Integration Catalog](https://keyfactor.github.io/integrations-catalog/content/pam) for the specific format of the `json` object.
+
+To have the __Server Password__ field resolved by the `Hashicorp-Vault` provider, the corresponding `json` object from the `Hashicorp-Vault` extension needs to be copied and filed in with the correct information:
+
+~~~ json
+{"Secret":"my-kv-secret","Key":"myServerPassword"}
+~~~
+
+This text would be entered in as the value for the __Server Password__, instead of entering in the actual password. The Orchestrator will attempt to use the PAM Provider to retrieve the __Server Password__. If PAM should not be used, just directly enter in the value for the field.

--- a/readme-templates/readme_platform_pam.md
+++ b/readme-templates/readme_platform_pam.md
@@ -10,6 +10,7 @@ If you have a hosted environment or need assistance completing this step, please
 The following are the parameter names and a description of the values needed to configure the {{ name }}.
 
 {% include "./readme-src/readme-paramtable.md" %}
+
 ![](images/config.png)
 
 {% include "./readme-src/readme-config.md" %}
@@ -44,5 +45,5 @@ In order to use the PAM Provider, the provider's configuration must be set in th
 ![](images/setting.png)
 
 After it is set up, you can now use your PAM Provider when configuring certificate stores. Any field that is treated as a Keyfactor secret, such as server passwords and certificate store passwords can be retrieved from your PAM Provider instead of being entered in directly as a secret.
-{% include "./readme-src/readme-server-password.md" %}
+
 ![](images/password.png)


### PR DESCRIPTION
2 problems were occurring - 1 in the actions readme template for pam

the readme-src reference removed here is not used in any repo and is not clear what it was for.

the additional spacing added also prevents an error in Grid drawing from `readme-paramtable.md`