### PR TITLE
Upd upload action

### DIFF
--- a/.github/workflows/dotnet-build-and-release.yml
+++ b/.github/workflows/dotnet-build-and-release.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Upload Release Asset (x64)
         if: success() && env.CREATE_RELEASE == 'True'
         id: upload-release-asset-x64
-        uses: keyfactor/upload-release-asset@upd-upload-action
+        uses: keyfactor/upload-release-assets@v1.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/dotnet-build-and-release.yml
+++ b/.github/workflows/dotnet-build-and-release.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Upload Release Asset (x64)
         if: success() && env.CREATE_RELEASE == 'True'
         id: upload-release-asset-x64
-        uses: keyfactor/upload-release-asset@v1
+        uses: keyfactor/upload-release-asset@upd-upload-action
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/dotnet-build-and-release.yml
+++ b/.github/workflows/dotnet-build-and-release.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Upload Release Asset (x64)
         if: success() && env.CREATE_RELEASE == 'True'
         id: upload-release-asset-x64
-        uses: actions/upload-release-asset@v1
+        uses: keyfactor/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/dotnet-build-and-release.yml
+++ b/.github/workflows/dotnet-build-and-release.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Upload Release Asset (x64)
         if: success() && env.CREATE_RELEASE == 'True'
         id: upload-release-asset-x64
-        uses: keyfactor/upload-release-assets@v1.1.0
+        uses: keyfactor/upload-release-asset@upd-upload-action
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/dotnet-build-and-release.yml
+++ b/.github/workflows/dotnet-build-and-release.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Upload Release Asset (x64)
         if: success() && env.CREATE_RELEASE == 'True'
         id: upload-release-asset-x64
-        uses: keyfactor/upload-release-asset@upd-upload-action
+        uses: keyfactor/upload-release-asset@v1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
upload-release-asset v1.1 has been rebuilt with updated @actions/core package to remove deprecateion warnings.